### PR TITLE
Fix dependency error

### DIFF
--- a/lib/termbox.rb
+++ b/lib/termbox.rb
@@ -1,4 +1,3 @@
-require "bundler/setup"
 require "ffi"
 
 lib = File.expand_path('../../', __FILE__)


### PR DESCRIPTION
I get the following error:

`/Users/ryguy/.rvm/gems/ruby-2.2.0/gems/rb_termbox-0.2.0/lib/termbox.rb:2:in`require': cannot load such file -- ffi (LoadError)`

When using in a non-Bundler project. This fixes that.
