### PR TITLE
Add blocking to tb_peek and tb_poll

### DIFF
--- a/lib/termbox.rb
+++ b/lib/termbox.rb
@@ -45,8 +45,8 @@ module Termbox
 
     # with 0 returns current input mode
     attach_function :tb_select_input_mode, [:int], :int
-    attach_function :tb_peek_event, [:pointer, :int], :int
-    attach_function :tb_poll_event, [:pointer], :int
+    attach_function :tb_peek_event, [:pointer, :int], :int, {:blocking => true}
+    attach_function :tb_poll_event, [:pointer], :int, {:blocking => true}
   end
 
   module_function :initialize_library, :termbox_library_path

--- a/lib/termbox/version.rb
+++ b/lib/termbox/version.rb
@@ -1,3 +1,3 @@
 module Termbox
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Add annotation to tb_peek and tb_poll to allow multithreading while ruby is waiting for them to return. This was causing issues in code like https://gist.github.com/Radvendii/f90e558751a0f53d8f70.
